### PR TITLE
Add onboarding comments to core startup, module configs, and mapped properties

### DIFF
--- a/Application/FoundryApp.cs
+++ b/Application/FoundryApp.cs
@@ -10,6 +10,8 @@ namespace CyberHub.Foundry
     /// </summary>
     public class FoundryApp
     {
+        // Foundry initializes itself as soon as the type is loaded so downstream code can
+        // immediately request services without a manual bootstrap call.
         private static FoundryApp _instance = new ();
         
         /// <summary>
@@ -18,14 +20,22 @@ namespace CyberHub.Foundry
         private readonly ServiceContainer services = new();
         
         private FoundryAppConfig config;
+        // Runtime lookup table used by GetConfig<T>() to return module-specific settings quickly.
         private readonly Dictionary<Type, FoundryModuleConfig> moduleConfigs = new();
 
         internal FoundryApp()
         {
-            // Add config services
+            // The app configuration lives in a Resources folder so it can be loaded both
+            // in editor tooling and in player builds without an explicit scene reference.
             config = Resources.Load<FoundryAppConfig>("FoundryAppConfig");
             Debug.Assert(config, "FoundryAppConfig not found!");
+
+            // Each module is given a chance to register its service constructors and then
+            // instantiate only the services that are marked as enabled in project settings.
             config.RegisterServices(this);
+
+            // Cache module configs by their concrete type so call sites can query config via
+            // GetConfig<T>() without walking the modules array every time.
             foreach(var module in config.modules)
                 moduleConfigs.Add(module.GetType(), module);
         }
@@ -37,6 +47,8 @@ namespace CyberHub.Foundry
         /// <param name="service">Class instance that implements the interface</param>
         public void AddService(Type type, object service)
         {
+            // ServiceContainer does not guard against accidental overrides, so we assert here
+            // to catch duplicate registrations early during startup.
             Debug.Assert(services.GetService(type) == null, "Service implementing " + type.Name +" already exists!");
             services.AddService(type, service);
         }
@@ -49,6 +61,8 @@ namespace CyberHub.Foundry
         public object GetService(Type type)
         {
             var result = services.GetService(type);
+            // A missing service is considered an invalid app state for this API. If callers
+            // want nullable behavior they should use TryGetService.
             Debug.Assert(result != null, "Service implementing " + type.FullName + " not found!");
             return result;
         }
@@ -61,6 +75,7 @@ namespace CyberHub.Foundry
         /// <returns>true if the service was found</returns>
         public bool TryGetService(Type type, out object service)
         {
+            // Non-throwing/ non-asserting variant used by optional integrations.
             service = services.GetService(type);
             return service != null;
         }
@@ -102,6 +117,7 @@ namespace CyberHub.Foundry
         {
             if (_instance.TryGetService(typeof(T), out object s))
             {
+                // Safe because we key services by the interface type passed to TryGetService<T>().
                 service = s as T;
                 return true;
             }
@@ -118,6 +134,8 @@ namespace CyberHub.Foundry
         public static T GetConfig<T>()
         where T : FoundryModuleConfig
         {
+            // Config lookup intentionally returns null instead of asserting; modules may be
+            // optional in a project and call sites can branch based on availability.
             if(_instance.moduleConfigs.TryGetValue(typeof(T), out FoundryModuleConfig config))
                 return config as T;
             return null;

--- a/Application/FoundryAppConfig.cs
+++ b/Application/FoundryAppConfig.cs
@@ -6,9 +6,14 @@ namespace CyberHub.Foundry
 {
     public class FoundryAppConfig : ScriptableObject
     {
+        // Ordered list of module configs participating in startup. Each module can expose
+        // its own toggles while still sharing a single boot pipeline.
         public FoundryModuleConfig[] modules = Array.Empty<FoundryModuleConfig>();
+
         public void RegisterServices(FoundryApp app)
         {
+            // Startup is delegated to each module so packages can stay loosely coupled and
+            // only register the services they own.
             foreach (var module in modules)
                 module.RegisterServices(app);
         }
@@ -16,6 +21,8 @@ namespace CyberHub.Foundry
 #if UNITY_EDITOR
         public static FoundryAppConfig GetAsset()
         {
+            // Editor helper used by setup tooling: load existing config or lazily create one
+            // at the conventional Resources path so runtime boot can always find it.
             var asset = Resources.Load<FoundryAppConfig>("FoundryAppConfig");
             if (asset == null)
             {

--- a/Application/FoundryCoreModuleConfig.cs
+++ b/Application/FoundryCoreModuleConfig.cs
@@ -12,13 +12,17 @@ namespace CyberHub.Foundry
     /// </summary>
     public abstract class FoundryModuleConfig : ScriptableObject
     {
+        // Factory delegate modules use to build service instances at startup time.
         public delegate object ServiceConstructor();
 
+        // Default location where module settings assets are stored in Unity projects.
         public const string ConfigPath = "Assets/Foundry/Settings";
         
         #if UNITY_EDITOR
         protected static T GetOrCreateAsset<T>(string assetName) where T : FoundryModuleConfig
         {
+            // Shared editor utility for module packages so each module can expose a one-click
+            // config asset without duplicating path/creation logic.
             var assetPath = Path.Join(ConfigPath, assetName);
             var asset = UnityEditor.AssetDatabase.LoadAssetAtPath<T>(assetPath);  
             if (asset == null)
@@ -34,6 +38,8 @@ namespace CyberHub.Foundry
         [Serializable]
         public class SerializedType
         {
+            // Assembly-qualified names survive Unity serialization and let us resolve
+            // interface types after domain reloads and across editor sessions.
             [SerializeField]
             private string assemblyQualifiedName;
             
@@ -58,6 +64,8 @@ namespace CyberHub.Foundry
             public Type Type
             {
                 get {
+                    // Type.GetType can fail when assemblies move/rename. We intentionally
+                    // swallow failures here and let callers validate with assertions.
                     try
                     {
                         return Type.GetType(assemblyQualifiedName);
@@ -118,14 +126,19 @@ namespace CyberHub.Foundry
 
         internal void RegisterServices(FoundryApp instance)
         {
+            // Step 1: ask the module which services it *could* construct.
             Dictionary<Type, ServiceConstructor> constructors = new();
             RegisterServices(constructors);
             
+            // Step 2: instantiate only the services currently enabled in this config asset.
             foreach (var system in EnabledServices)
             {
                 Type systemType = system;
+                // If a type cannot be resolved (assembly rename, package removed, etc.),
+                // assert so the config can be repaired rather than silently skipping it.
                 Debug.Assert(systemType != null, $"Could not find type {system}!");
                 Debug.Assert(constructors.ContainsKey(systemType), $"{GetType().Name} did not provide a constructor for {systemType.Name}!");
+                // Constructors are deferred until now so disabled services pay zero runtime cost.
                 instance.AddService(systemType, constructors[systemType]());
                 Debug.Log("Registered service: " + systemType.FullName + " from module " + GetType().Name);
             }
@@ -190,6 +203,9 @@ namespace CyberHub.Foundry
         public override void OnInspectorGUI()
         {
             var config = (FoundryModuleConfig) target;
+
+            // Custom inspector keeps the enabled-service list visible/read-only while allowing
+            // subclasses to draw their own settings below.
 
             if (config.EnabledServices.Count != 0)
             {

--- a/ComponentMapping/MappedProperties.cs
+++ b/ComponentMapping/MappedProperties.cs
@@ -41,6 +41,8 @@ namespace CyberHub.Foundry
         /// We attempt to cache on property lookup, this is the cached value. This is used to avoid having to do a lookup,
         /// since as of now there are no cases where we have multiple implementations of the same property active at once.
         /// </summary>
+        // Last deserialized property payload. This micro-cache avoids repeated binary
+        // deserialization when tools query the same implementation multiple times.
         private object propCache;
         
         /// <summary>
@@ -51,6 +53,8 @@ namespace CyberHub.Foundry
         public T GetProps<T>(string implementationId)
         where T: class, new()
         {
+            // Fast path: if we already deserialized this implementation into the requested
+            // type, return it directly.
             if (propCache is T cache)
                 return cache;
             
@@ -58,6 +62,8 @@ namespace CyberHub.Foundry
             {
                 if (impl.implementationId == implementationId)
                 {
+                    // BinaryFormatter is used here for legacy compatibility with existing
+                    // serialized payloads produced by older Foundry integrations.
                     var stream = new MemoryStream(impl.data);
                     BinaryFormatter bf = new();
 
@@ -67,6 +73,8 @@ namespace CyberHub.Foundry
                     }
                     catch (Exception e)
                     {
+                        // Corrupt payloads are reset so future reads start clean instead of
+                        // repeatedly throwing every time this component is inspected.
                         impl.data = new byte[0];
                         return new T();
                     }
@@ -81,6 +89,8 @@ namespace CyberHub.Foundry
         where T: class
         {
             
+            // Serialize the provider-specific settings object into a byte[] blob so this
+            // wrapper can stay implementation-agnostic.
             var stream = new MemoryStream();
             BinaryFormatter bf = new();
             bf.Serialize(stream, value);
@@ -90,11 +100,13 @@ namespace CyberHub.Foundry
             {
                 if (impl.implementationId == implementationId)
                 {
+                    // Update in place when the implementation already exists.
                     impl.data = data;
                     return;
                 }
             }
             
+            // First time this implementation is seen on the component, append a new entry.
             serializedProperties.Add(new MappedPropertyImpl()
             {
                 implementationId = implementationId,


### PR DESCRIPTION
### Motivation
- Improve code readability and onboarding for new contributors by documenting Foundry's bootstrap and configuration flows. 
- Clarify expectations around service registration, optional service access, and editor-time asset behavior so maintainers can make safe changes. 
- Explain legacy deserialization and caching semantics in mapped property handling to reduce accidental regressions.

### Description
- Added explanatory inline comments in `Application/FoundryApp.cs` documenting the singleton bootstrap behavior, `Resources`-based config loading, service registration assertions, `TryGetService` vs `GetService` semantics, and the module config lookup cache. 
- Added short onboarding comments in `Application/FoundryAppConfig.cs` describing the modules array intent and editor helper behavior for lazy asset creation. 
- Expanded comments in `Application/FoundryCoreModuleConfig.cs` covering the `ServiceConstructor` factory pattern, editor helper `GetOrCreateAsset`, `SerializedType` resolution caveats, and the enabled-service registration flow. 
- Documented cache intent, legacy `BinaryFormatter` usage, corruption handling, and update-vs-add behavior in `ComponentMapping/MappedProperties.cs` so integrators understand trade-offs.

### Testing
- Ran repository validation commands `git diff -- Application/FoundryApp.cs Application/FoundryAppConfig.cs Application/FoundryCoreModuleConfig.cs ComponentMapping/MappedProperties.cs` which completed successfully. 
- Verified working tree status with `git status --short` and committed the changes with `git commit -m "Add extensive inline comments for core startup and mapping flows"`, both of which succeeded. 
- No automated unit or integration test suites were executed for this comment-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a839daeb1c832a81c0aed4c3b025b1)